### PR TITLE
Remove duplicate rules and remove jsx a11y settings

### DIFF
--- a/.changeset/grumpy-views-think.md
+++ b/.changeset/grumpy-views-think.md
@@ -1,0 +1,5 @@
+---
+'@rajzik/eslint-config': patch
+---
+
+Remove duplicate rules remove a11y settings and enable next rule

--- a/packages/eslint-config/src/nextjs.ts
+++ b/packages/eslint-config/src/nextjs.ts
@@ -13,8 +13,6 @@ const config: ConfigArray = [
     rules: {
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs['core-web-vitals'].rules,
-      // TypeError: context.getAncestors is not a function
-      '@next/next/no-duplicate-head': 'off',
     },
   },
 ];

--- a/packages/eslint-config/src/react.ts
+++ b/packages/eslint-config/src/react.ts
@@ -19,7 +19,6 @@ const config: ConfigArray = [
       ...reactPlugin.configs['jsx-runtime'].rules,
       ...hooksPlugin.configs.recommended.rules,
       ...jsxA11y.configs.recommended.rules,
-      ...stylisticPlugin.configs['disable-legacy'].rules,
 
       '@stylistic/jsx-quotes': ['error', 'prefer-double'],
       '@stylistic/jsx-sort-props': 'warn',
@@ -61,21 +60,6 @@ const config: ConfigArray = [
     settings: {
       react: {
         version: 'detect',
-      },
-      'jsx-a11y': {
-        polymorphicPropName: 'as',
-        components: {
-          Button: 'button',
-          CancelButton: 'button',
-          DeleteButton: 'button',
-          SaveButton: 'button',
-          EditButton: 'button',
-          ShareButton: 'button',
-          ImportButton: 'button',
-          NumberInput: 'input',
-          TextInput: 'input',
-          TextField: 'input',
-        },
       },
     },
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated ESLint configurations for Next.js and React projects to align with default plugin behaviors and removed custom accessibility and stylistic settings.
- **Chores**
  - Cleaned up outdated or unnecessary ESLint rule overrides and settings for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->