### PR TITLE
remove migrate plugin

### DIFF
--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -2,15 +2,9 @@ import baseConfig from '@rajzik/eslint-config';
 import nodeConfig from '@rajzik/eslint-config/node';
 import prettierConfig from '@rajzik/eslint-config/prettier';
 import turboConfig from '@rajzik/eslint-config/turbo';
-import migratePlugin from '@stylistic/eslint-plugin-migrate';
 
 /** @type {import('@rajzik/eslint-config').Config} */
 const config = [
-  {
-    plugins: {
-      '@stylistic/migrate': migratePlugin,
-    },
-  },
   ...baseConfig,
   ...nodeConfig,
   ...turboConfig,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -65,7 +65,6 @@
   "devDependencies": {
     "@rajzik/prettier-config": "workspace:*",
     "@rajzik/tsconfig": "workspace:*",
-    "@stylistic/eslint-plugin-migrate": "^4.4.1",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint @stylistic/migrate/migrate-js: "error" */
 // @ts-check
 import path from 'node:path';
 

--- a/packages/eslint-config/src/nextjs.ts
+++ b/packages/eslint-config/src/nextjs.ts
@@ -1,5 +1,3 @@
-/* eslint @stylistic/migrate/migrate-js: "error" */
-
 import type { ConfigArray } from 'typescript-eslint';
 
 import nextPlugin from '@next/eslint-plugin-next';

--- a/packages/eslint-config/src/react.ts
+++ b/packages/eslint-config/src/react.ts
@@ -1,4 +1,3 @@
-/* eslint @stylistic/migrate/migrate-js: "error" */
 import type { ConfigArray } from 'typescript-eslint';
 
 import stylisticPlugin from '@stylistic/eslint-plugin';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,9 +279,6 @@ importers:
       '@rajzik/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@stylistic/eslint-plugin-migrate':
-        specifier: ^4.4.1
-        version: 4.4.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.0.3
@@ -630,9 +627,6 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint-stylistic/metadata@4.4.1':
-    resolution: {integrity: sha512-ZDpYZSB5dTzWyrBRTUWz202jxdMtgEz9ymbzyAiy70d7fe53JauGvRWl21LvC5HyWYKqpGS/9kbNhOKv4fkrfw==}
-
   '@eslint/compat@1.3.0':
     resolution: {integrity: sha512-ZBygRBqpDYiIHsN+d1WyHn3TYgzgpzLEcgJUxTATyiInQbKZz6wZb6+ljwdg8xeeOe4v03z6Uh6lELiw0/mVhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -925,10 +919,6 @@ packages:
   '@simple-libs/stream-utils@1.1.0':
     resolution: {integrity: sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==}
     engines: {node: '>=18'}
-
-  '@stylistic/eslint-plugin-migrate@4.4.1':
-    resolution: {integrity: sha512-9HgQi6MfLp2ctYnrHbqkgEFHNwwSKoU7rGV7dJsVwWyVhlgglh8AvkfcYxY1mnyMCMZulFNs5XEQsxUaaS0UrQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@stylistic/eslint-plugin@5.0.0':
     resolution: {integrity: sha512-nVV2FSzeTJ3oFKw+3t9gQYQcrgbopgCASSY27QOtkhEGgSfdQQjDmzZd41NeT1myQ8Wc6l+pZllST9qIu4NKzg==}
@@ -4057,8 +4047,6 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint-stylistic/metadata@4.4.1': {}
-
   '@eslint/compat@1.3.0(eslint@9.29.0(jiti@2.4.2))':
     optionalDependencies:
       eslint: 9.29.0(jiti@2.4.2)
@@ -4357,15 +4345,6 @@ snapshots:
   '@simple-libs/stream-utils@1.1.0':
     dependencies:
       '@types/node': 22.15.32
-
-  '@stylistic/eslint-plugin-migrate@4.4.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-stylistic/metadata': 4.4.1
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - typescript
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@2.4.2))':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed references to the stylistic migrate ESLint plugin and its related configuration.
  - Cleaned up ESLint directive comments associated with the removed plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->