### PR TITLE
Remove unused property

### DIFF
--- a/.changeset/dry-tigers-help.md
+++ b/.changeset/dry-tigers-help.md
@@ -1,0 +1,5 @@
+---
+'@rajzik/oxlint-config': patch
+---
+
+Remove unused property

--- a/.changeset/light-hotels-lose.md
+++ b/.changeset/light-hotels-lose.md
@@ -1,0 +1,6 @@
+---
+'@rajzik/oxlint-config': patch
+'@rajzik/oxfmt-config': patch
+---
+
+Fix bundled dependencies

--- a/packages/oxfmt-config/tsdown.config.ts
+++ b/packages/oxfmt-config/tsdown.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig([
-  {
-    entry: ['./src/*.ts'],
-    sourcemap: true,
-    dts: true,
+export default defineConfig({
+  dts: true,
+  format: 'esm',
+  entry: ['./src/**/*.ts'],
+  sourcemap: true,
+  deps: {
+    neverBundle: ['oxfmt'],
   },
-]);
+});

--- a/packages/oxlint-config/src/buildOxlintConfig.ts
+++ b/packages/oxlint-config/src/buildOxlintConfig.ts
@@ -42,12 +42,6 @@ export interface BuildOxlintConfigArgs {
    */
   readonly turbo?: boolean;
   /**
-   * When `epa: true` enables epa specific rules.
-   *
-   * @default true
-   */
-  readonly epa?: boolean;
-  /**
    * When `jsdoc: true` enables jsdoc specific rules.
    *
    * @default false
@@ -84,7 +78,7 @@ export interface BuildOxlintConfigArgs {
  *       },
  *     },
  *   });
- *   ```
+ *   ```;
  *
  * @function buildOxlintConfig
  * @param {BuildOxlintConfigArgs} configuration Configuration
@@ -98,7 +92,6 @@ export const buildOxlintConfig = (
     node = false,
     turbo = false,
     jsdoc = false,
-    epa: _epa = true,
     library = false,
     overrides,
   } = configuration;

--- a/packages/oxlint-config/tsdown.config.ts
+++ b/packages/oxlint-config/tsdown.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig([
-  {
-    entry: ['./src/*.ts'],
-    sourcemap: true,
-    dts: true,
+export default defineConfig({
+  dts: true,
+  format: 'esm',
+  entry: ['./src/**/*.ts'],
+  sourcemap: true,
+  deps: {
+    neverBundle: ['oxlint'],
   },
-]);
+});

--- a/packages/prettier-preset/src/index.ts
+++ b/packages/prettier-preset/src/index.ts
@@ -1,5 +1,3 @@
-/* oxlint-disable typescript-eslint/no-deprecated */
-
 import type { PluginConfig } from '@ianvs/prettier-plugin-sort-imports';
 import type { Config } from 'prettier';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Packaging/build config changes can alter published artifacts and runtime dependency resolution. The `epa` removal is low risk but could be a breaking change for consumers who were passing it despite being unused.
> 
> **Overview**
> Updates the `tsdown` build configs for `@rajzik/oxlint-config` and `@rajzik/oxfmt-config` to emit ESM output, expand the entry glob to `src/**/*.ts`, and mark `oxlint`/`oxfmt` as `neverBundle` to fix bundled dependency behavior.
> 
> Removes the unused `epa` option from `BuildOxlintConfigArgs`/`buildOxlintConfig` and drops an unnecessary `oxlint-disable` header from the `prettier-preset` entrypoint. Two changesets are added to publish patch releases for these packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bdcb16c6229afd2489c9ed6ae691cdc36dccb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->