### PR TITLE
fix(oxlint): keep readonly checks for libraries

### DIFF
--- a/.changeset/remove-readonly-library-rule.md
+++ b/.changeset/remove-readonly-library-rule.md
@@ -1,0 +1,5 @@
+---
+'@rajzik/oxlint-config': patch
+---
+
+Removed the library preset relaxation for readonly parameter types.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -8,6 +8,7 @@ export default buildOxlintConfig({
     ignorePatterns: [
       '**/fixtures/**',
       '**/dist/**',
+      '**/lib/**',
       'node_modules',
       '**/coverage/**',
     ],

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -240,7 +240,7 @@ export default defineConfig({
 
 ### `libraryConfig`
 
-Applies library-specific rule relaxations.
+Applies library-specific rule configuration.
 
 This preset must be last in the `extends` array when used manually.
 

--- a/packages/oxlint-config/src/buildOxlintConfig.ts
+++ b/packages/oxlint-config/src/buildOxlintConfig.ts
@@ -48,7 +48,7 @@ export interface BuildOxlintConfigArgs {
    */
   readonly jsdoc?: boolean;
   /**
-   * When `library: true` enables library specific rules.
+   * When `library: true` appends the library preset after all other extends.
    *
    * @default false;
    */

--- a/packages/oxlint-config/src/library.ts
+++ b/packages/oxlint-config/src/library.ts
@@ -17,9 +17,4 @@ import { defineConfig } from 'oxlint';
  *   });
  *   ```;
  */
-export const libraryConfig = defineConfig({
-  rules: {
-    // Typescript disabled rules
-    'typescript/prefer-readonly-parameter-types': 'allow',
-  },
-});
+export const libraryConfig = defineConfig({});

--- a/packages/oxlint-config/src/library.ts
+++ b/packages/oxlint-config/src/library.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'oxlint';
 
 /**
- * Library specific rules. To build fully configured oxlint configuration @see
+ * Library specific config. To build fully configured oxlint configuration @see
  * {buildOxlintConfig}.
  *
  * > This config must be last in extends array to work properly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the `libraryConfig` override that allowed `typescript/prefer-readonly-parameter-types`.
- Add `**/lib/**` to the root `oxlint.config.ts` ignore patterns.
- Update `@rajzik/oxlint-config` README wording and add a patch changeset.

### Testing
- Pending local validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12e7cb31-b0dd-4327-80fd-c1e5790fee31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12e7cb31-b0dd-4327-80fd-c1e5790fee31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

