### PR TITLE
chore: relax readonly type usage

### DIFF
--- a/.changeset/sweet-buckets-cheer.md
+++ b/.changeset/sweet-buckets-cheer.md
@@ -1,0 +1,6 @@
+---
+'@rajzik/danger-configuration': patch
+'@rajzik/oxlint-config': patch
+---
+
+Removed readonly modifiers from exported option types and function arguments, and enabled the library oxlint preset for the repository config.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -4,6 +4,7 @@ export default buildOxlintConfig({
   node: true,
   turbo: true,
   jsdoc: true,
+  library: true,
   overrides: {
     ignorePatterns: [
       '**/fixtures/**',

--- a/packages/config-danger/src/adr.ts
+++ b/packages/config-danger/src/adr.ts
@@ -12,11 +12,11 @@ import {
 /** Options for checking ADR (Architecture Decision Record) requirements. */
 export type CheckAdrOptions = CommonOptions & {
   /** Threshold for number of line changes before requiring ADR. Defaults to 200. */
-  readonly changeThreshold?: number;
+  changeThreshold?: number;
   /** URL to documentation about ADR requirements. */
-  readonly docsUrl?: string;
+  docsUrl?: string;
   /** Additional file patterns to exclude from change count calculation. */
-  readonly exclusions?: readonly string[];
+  exclusions?: string[];
 };
 
 /**
@@ -37,7 +37,7 @@ export type CheckAdrOptions = CommonOptions & {
  */
 export async function checkForADR(
   docsPath: string,
-  options: Readonly<CheckAdrOptions> = {},
+  options: CheckAdrOptions = {},
 ) {
   if (isRevert()) {
     return;

--- a/packages/config-danger/src/code.ts
+++ b/packages/config-danger/src/code.ts
@@ -19,11 +19,11 @@ const changedSrcFiles = updatedFiles.filter(
 );
 
 /** Options for test-related checks. */
-export interface TestOptions extends Readonly<CommonOptions> {
+export interface TestOptions extends CommonOptions {
   /** Regular expression pattern to ignore certain files from test checks. */
-  readonly ignorePattern?: Readonly<RegExp>;
+  ignorePattern?: RegExp;
   /** Root directory path to scope the check to a specific part of the codebase. */
-  readonly root?: string;
+  root?: string;
 }
 
 /**
@@ -67,7 +67,7 @@ export function checkForInvalidLocks() {
  * @param {boolean} [props.fail] - If true, fail the check instead of warning.
  *   Default is `false`
  */
-export function checkForAnyTests(props: Readonly<TestOptions> = {}) {
+export function checkForAnyTests(props: TestOptions = {}) {
   const { root, ...options } = props;
   if (isRevert()) {
     return;
@@ -103,7 +103,7 @@ export function checkForAnyTests(props: Readonly<TestOptions> = {}) {
  * @param {boolean} [props.fail] - If true, fail the check instead of warning.
  *   Default is `false`
  */
-export function checkSourceFilesHaveTests(props: Readonly<TestOptions> = {}) {
+export function checkSourceFilesHaveTests(props: TestOptions = {}) {
   const { ignorePattern, root, ...options } = props;
   if (isRevert()) {
     return;
@@ -157,7 +157,7 @@ export function checkSourceFilesHaveTests(props: Readonly<TestOptions> = {}) {
 /** Options for snapshot testing checks. */
 export interface SnapshotOptions {
   /** URL to documentation about snapshot testing deprecation. */
-  readonly docsUrl?: string;
+  docsUrl?: string;
 }
 
 const fileFilter = (file: string) =>

--- a/packages/config-danger/src/helpers.ts
+++ b/packages/config-danger/src/helpers.ts
@@ -32,7 +32,7 @@ export const touchedFiles = [
  * @param {string} msg - Debug message to log
  * @param {...string} args - Additional arguments to include in the message
  */
-export function debug(msg: string, ...args: readonly string[]) {
+export function debug(msg: string, ...args: string[]) {
   if (danger.git.modified_files.includes('dangerfile.js')) {
     message(`[debug] ${msg}`, ...args);
   }

--- a/packages/config-danger/src/types.ts
+++ b/packages/config-danger/src/types.ts
@@ -1,5 +1,5 @@
 /** Common options shared across multiple danger checks. */
 export interface CommonOptions {
   /** If true, fail the check instead of warning. Defaults to false (warn). */
-  readonly fail?: boolean;
+  fail?: boolean;
 }

--- a/packages/oxlint-config/src/buildOxlintConfig.ts
+++ b/packages/oxlint-config/src/buildOxlintConfig.ts
@@ -1,5 +1,3 @@
-/* oxlint-disable typescript-eslint/prefer-readonly-parameter-types */
-
 import type { OxlintConfig } from 'oxlint';
 
 import { defineConfig } from 'oxlint';
@@ -17,9 +15,8 @@ import { turboConfig } from './turbo';
  * @returns {boolean} IsDefined
  */
 const isDefined = (
-  input: Readonly<OxlintConfig> | boolean | undefined,
-): input is Readonly<OxlintConfig> =>
-  input !== undefined && typeof input !== 'boolean';
+  input: OxlintConfig | boolean | undefined,
+): input is OxlintConfig => input !== undefined && typeof input !== 'boolean';
 
 export interface BuildOxlintConfigArgs {
   /**
@@ -28,36 +25,36 @@ export interface BuildOxlintConfigArgs {
    *
    * @default false
    */
-  readonly react?: boolean;
+  react?: boolean;
   /**
    * When `node: true` enables node specific rules.
    *
    * @default false
    */
-  readonly node?: boolean;
+  node?: boolean;
   /**
    * When `turbo: true` enables turborepo specific rules.
    *
    * @default false
    */
-  readonly turbo?: boolean;
+  turbo?: boolean;
   /**
    * When `jsdoc: true` enables jsdoc specific rules.
    *
    * @default false
    */
-  readonly jsdoc?: boolean;
+  jsdoc?: boolean;
   /**
    * When `library: true` enables library specific rules.
    *
    * @default false;
    */
-  readonly library?: boolean;
+  library?: boolean;
   /**
    * Overrides of the configuration, supports all possible overrides. Extends
    * array is appended not overridden.
    */
-  readonly overrides?: Readonly<OxlintConfig>;
+  overrides?: OxlintConfig;
 }
 
 /**
@@ -85,7 +82,7 @@ export interface BuildOxlintConfigArgs {
  * @returns {OxlintConfig} Oxlint config
  */
 export const buildOxlintConfig = (
-  configuration: Readonly<BuildOxlintConfigArgs> = {},
+  configuration: BuildOxlintConfigArgs = {},
 ): OxlintConfig => {
   const {
     react = false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove `readonly` modifiers from exported option interfaces and function argument types.
- Enable the library oxlint preset in the repository root config.
- Add a patch changeset for the affected publishable packages.

## Validation
- `pnpm --filter @rajzik/oxlint-config typecheck`
- `pnpm --filter @rajzik/danger-configuration lint`
- `pnpm --filter @rajzik/oxlint-config lint`
- `pnpm --filter @rajzik/danger-configuration build`
- `pnpm --filter @rajzik/oxlint-config build`
- `pnpm exec oxfmt oxlint.config.ts packages/oxlint-config/src/buildOxlintConfig.ts packages/config-danger/src/types.ts packages/config-danger/src/helpers.ts packages/config-danger/src/code.ts packages/config-danger/src/adr.ts .changeset/sweet-buckets-cheer.md`

Note: full `pnpm lint` currently fails in `@rajzik/prettier-config` on an existing `typescript-eslint(no-deprecated)` warning for `baseConfig`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c11d581c-2f92-43fa-8098-f84b6eb143d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c11d581c-2f92-43fa-8098-f84b6eb143d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OXLint library preset mode is now enabled in default configuration.

* **Improvements**
  * Configuration option types are now mutable, enabling greater flexibility for customization without TypeScript constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->