### PR TITLE
Relax peer dependency catalog ranges

### DIFF
--- a/.changeset/relax-peer-dependency-ranges.md
+++ b/.changeset/relax-peer-dependency-ranges.md
@@ -1,0 +1,6 @@
+---
+'@rajzik/oxlint-config': patch
+'@rajzik/prettier-config': patch
+---
+
+Relaxed peer dependency ranges and moved the Tailwind Prettier plugin version into the shared catalog.

--- a/packages/prettier-preset/package.json
+++ b/packages/prettier-preset/package.json
@@ -48,7 +48,7 @@
     "@ianvs/prettier-plugin-sort-imports": "catalog:",
     "@rajzik/oxfmt-config": "workspace:*",
     "prettier-plugin-packagejson": "catalog:",
-    "prettier-plugin-tailwindcss": "0.7.3"
+    "prettier-plugin-tailwindcss": "catalog:"
   },
   "devDependencies": {
     "@rajzik/tsconfig": "workspace:*",
@@ -57,7 +57,7 @@
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
     "prettier": "catalog:",
-    "prettier-plugin-tailwindcss": "0.7.3",
+    "prettier-plugin-tailwindcss": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ catalogs:
       specifier: 0.46.0
       version: 0.46.0
     oxlint:
-      specifier: 1.61.0
+      specifier: ^1.61.0
       version: 1.61.0
     oxlint-tsgolint:
-      specifier: 0.22.0
+      specifier: ^0.22.0
       version: 0.22.0
     prettier:
       specifier: 3.8.3
@@ -30,6 +30,9 @@ catalogs:
     prettier-plugin-packagejson:
       specifier: 3.0.2
       version: 3.0.2
+    prettier-plugin-tailwindcss:
+      specifier: ^0.7.3
+      version: 0.7.3
     tsdown:
       specifier: 0.21.10
       version: 0.21.10
@@ -203,7 +206,7 @@ importers:
         specifier: 'catalog:'
         version: 3.0.2(prettier@3.8.3)
       prettier-plugin-tailwindcss:
-        specifier: 0.7.3
+        specifier: 'catalog:'
         version: 0.7.3(@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.3))(prettier@3.8.3)
     devDependencies:
       '@rajzik/tsconfig':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,10 +8,11 @@ catalog:
   '@types/node': 25.6.0
   eslint: 10.2.1
   oxfmt: 0.46.0
-  oxlint: 1.61.0
-  oxlint-tsgolint: 0.22.0
+  oxlint: ^1.61.0
+  oxlint-tsgolint: ^0.22.0
   prettier: 3.8.3
   prettier-plugin-packagejson: 3.0.2
+  prettier-plugin-tailwindcss: ^0.7.3
   tsdown: 0.21.10
   turbo: 2.9.6
   typescript: 6.0.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Relax `oxlint` and `oxlint-tsgolint` catalog ranges so published peer dependencies use compatible minor ranges.
- Move `prettier-plugin-tailwindcss` to the shared catalog and consume it via `catalog:` in `@rajzik/prettier-config`.
- Add a changeset for the affected publishable packages.

## Testing
- `pnpm install --lockfile-only`
- `pnpm --filter @rajzik/oxlint-config typecheck`
- `pnpm --filter @rajzik/prettier-config typecheck`
- `pnpm --filter @rajzik/oxlint-config pack --pack-destination /tmp/configs-pack-check`
- `pnpm --filter @rajzik/prettier-config pack --pack-destination /tmp/configs-pack-check`
- `python3` tarball manifest inspection confirmed packed peer ranges
- `pnpm run lint:ws` (exit 0, existing workspace package warnings only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cba79829-19ed-46be-9295-990f9d4c12f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cba79829-19ed-46be-9295-990f9d4c12f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and development tooling dependencies.
  * Relaxed peer dependency ranges for improved compatibility.
  * Centralized version management through workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->