### PR TITLE
ci: dispatch PR checks after Renovate changesets

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: 🔥 Pull requests
 
 on:
   pull_request:
+  workflow_dispatch:
   check_run:
     types:
       - requested_action
@@ -22,12 +23,13 @@ env:
 jobs:
   danger:
     name: 🔥 Danger
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha }}
           fetch-depth: 0
 
       - uses: ./.github/common-actions/install

--- a/.github/workflows/sync-renovate-changesets.yml
+++ b/.github/workflows/sync-renovate-changesets.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   generate-changeset:
@@ -126,3 +127,9 @@ jobs:
             await exec.exec("git", ["add", fileName]);
             await exec.exec("git commit -C HEAD --amend --no-edit");
             await exec.exec("git push --force");
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "pull-request.yml",
+              ref: branch.stdout.trim(),
+            });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add manual dispatch support to the pull request workflow so checks can run on amended Renovate branch heads.
- Dispatch the pull request workflow after the Renovate changeset workflow force-pushes its amended commit.

### Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pull-request.yml .github/workflows/sync-renovate-changesets.yml`
- `pnpm test`
- Verified PR #1076 check rollup shows the pull request workflow jobs completed successfully on the branch head.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b388efb1-6e10-4745-a5c3-5f7245988313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b388efb1-6e10-4745-a5c3-5f7245988313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

