### PR TITLE
ci: run pull-request workflow on renovate branch pushes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,9 @@ name: 🔥 Pull requests
 
 on:
   pull_request:
+  push:
+    branches:
+      - "renovate/**"
   workflow_dispatch:
   check_run:
     types:


### PR DESCRIPTION
### Motivation
- Ensure the repository's pull-request pipeline runs when Renovate updates its branches by adding a `push` trigger scoped to Renovate branches so CI executes even if a PR event is not emitted.

### Description
- Update `.github/workflows/pull-request.yml` to add a `push` trigger limited to `branches: - "renovate/**"` while keeping the existing `pull_request`, `workflow_dispatch`, and `check_run` triggers unchanged.

### Testing
- Verified the workflow file diff with `git diff .github/workflows/pull-request.yml` and committed the change with `git commit -m "ci: run pull-request workflow on renovate branches"`, and no runtime GitHub Actions were executed from this local change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038c7d809c8329b89ee102fb3eb6c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow configuration to improve automated build and deployment processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajzik/configs/pull/1084)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->