### PR TITLE
Add `pull_request_target` trigger to pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: 🔥 Pull requests
 
 on:
   pull_request:
+  pull_request_target:
   workflow_dispatch:
   check_run:
     types:


### PR DESCRIPTION
### Motivation
- Include the `pull_request_target` event so the pull request workflow can run in the repository context for operations that require base-repo permissions.

### Description
- Add `pull_request_target:` under `on:` in `.github/workflows/pull-request.yml` to enable the `pull_request_target` trigger alongside the existing `pull_request` event.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038c7d809c8329b89ee102fb3eb6c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow trigger configuration for pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajzik/configs/pull/1086)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->