### PR TITLE
build(renovate): add 3-day minimum release age

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,7 @@
   "osvVulnerabilityAlerts": true,
   "npm": { "enabled": true },
   "updateLockFiles": true,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     { "matchManagers": ["github-actions"], "semanticCommitType": "ci" },
     {


### PR DESCRIPTION
### Motivation
- Delay Renovate from opening PRs for very recent releases by configuring `minimumReleaseAge` to `"3 days"` in the repo Renovate config.

### Description
- Added the key `"minimumReleaseAge": "3 days"` to `.github/renovate.json` immediately after `updateLockFiles` so Renovate will wait 3 days before proposing updates.

### Testing
- Verified the updated JSON parses successfully with `node -e "JSON.parse(require('fs').readFileSync('.github/renovate.json','utf8')); console.log('ok')"`, which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1400b73e308329a0fb1537454b95ea)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enforce a minimum waiting period before applying new releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajzik/configs/pull/1095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->