### PR TITLE
ci: use scoped @scaleway/changesets-renovate package in workflow

### DIFF
--- a/.github/workflows/changesets-renovate.yml
+++ b/.github/workflows/changesets-renovate.yml
@@ -29,4 +29,4 @@ jobs:
       - uses: ./.github/common-actions/install
 
       - name: Run changesets-renovate
-        run: pnpm dlx changesets-renovate
+        run: pnpm dlx @scaleway/changesets-renovate


### PR DESCRIPTION
### Motivation
- Ensure the Renovate changeset workflow invokes the fully scoped package so `pnpm dlx` resolves the correct package.

### Description
- Update `.github/workflows/changesets-renovate.yml` to run `pnpm dlx @scaleway/changesets-renovate` instead of `pnpm dlx changesets-renovate`.

### Testing
- Ran `pnpm format`, `git diff --check`, and `pnpm exec oxfmt .github/workflows/changesets-renovate.yml --ignore-path .gitignore`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf95a8ccc83299264db27d56ddd97)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for package management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->